### PR TITLE
(fix) Travis CI - remove '-w' on test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ node_modules/
 bower_components/
 
 # http://stackoverflow.com/questions/14744993/git-strange-branch-merge-error-that-i-am-not-sure-how-to-solve
-#.DS_Store
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha -w test/helpers/browser.js test/client/*.spec.js test/server/*.spec.js",
+    "test": "mocha test/helpers/browser.js test/client/*.spec.js test/server/*.spec.js",
     "dev:hot": "webpack-dev-server --hot --inline --progress --colors --watch --display-error-details --display-cached --content-base ./",
     "start-dev": "webpack -w | nodemon server/server.js"
   },


### PR DESCRIPTION
In package.json, removed '-w' to disable watch on npm test. If all goes well, Travis should now terminate upon completing tests and work normally instead of showing an error.