### PR TITLE
(fix) remove node v0.6 from .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ node_modules/
 bower_components/
 
 # http://stackoverflow.com/questions/14744993/git-strange-branch-merge-error-that-i-am-not-sure-how-to-solve
-#.DS_Store
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - '6.1'
   - '6.0'
   - '6'
-  - '0.6'
   - 'node'
  
 # Tells Travis that we're going to be using MongoDB

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha -w test/helpers/browser.js test/client/*.spec.js test/server/*.spec.js",
+    "test": "mocha test/helpers/browser.js test/client/*.spec.js test/server/*.spec.js",
     "dev:hot": "webpack-dev-server --hot --inline --progress --colors --watch --display-error-details --display-cached --content-base ./",
     "start-dev": "webpack -w | nodemon server/server.js"
   },


### PR DESCRIPTION
Currently, one of our Travis CI tests fail because it is initialized using node v0.6 (one of the default Node versions for Travis), specifically because npm install returns and error when installing react-dom package. Excluded v0.6 from the .travis.yml to fix the issue.