### PR TITLE
(docker) set up docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  web:
+    image: node:latest
+    volumes:
+      - ./:/usr/src/app
+    working_dir: /usr/src/app
+    env_file: .env
+    ports:
+      - "80:8000"
+    depends_on:
+      - mongo
+    command: npm run docker
+  mongo:
+    image: mongo
+    command: mongod

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test-all": "mocha test/helpers/browser.js test/client/*/*.spec.js test/server/*.spec.js test/server/*/*.spec.js test/db/*.spec.js",
     "dev:hot": "webpack-dev-server --hot --inline --progress --colors --watch --display-error-details --display-cached --content-base ./",
     "start-dev": "webpack -w | nodemon server/server.js",
-    "start": "node server/server.js"
+    "start": "node server/server.js",
+    "docker": "npm install && webpack && nodemon server/server.js"
   },
   "repository": {
     "type": "git",
@@ -67,6 +68,7 @@
     "chai-enzyme": "^0.6.0",
     "enzyme": "^2.6.0",
     "jsdom": "^9.8.3",
+    "nodemon": "1.11.0",
     "mocha": "^3.1.2",
     "mongoose": "^4.6.7",
     "react-addons-test-utils": "^15.4.0",

--- a/server/passport/config.js
+++ b/server/passport/config.js
@@ -5,7 +5,7 @@ const authHandler = require('../handlers/authHandler.js');
 passport.use(new GitHubStrategy({
   clientID: process.env.GITHUB_CLIENT_ID,
   clientSecret: process.env.GITHUB_CLIENT_SECRET,
-  callbackURL: 'http://localhost:8000/auth/github/callback'
+  callbackURL: process.env.GITHUB_CALLBACK_URL
 }, authHandler.login));
 
 passport.serializeUser((user, done) => done(null, user));

--- a/server/server.js
+++ b/server/server.js
@@ -63,8 +63,7 @@ console.log(`🌎  ===> server listening on port ${port}`);
 
 const mongoose = require('mongoose'); 
 
-// const uriString = process.env.MONGODB_URI || 'mongodb://localhost/gittalk'; // use deployed database if available in .env file
-const uriString = 'mongodb://localhost/gittalk'; // use local database
+const uriString = process.env.MONGODB_URI || 'mongodb://localhost/gittalk';
 
 mongoose.connect(uriString, (err, res) => {
   if (err) { 


### PR DESCRIPTION
- [x] Adds docker command to `package.json`
- [x] removes hardcoded uriString from `server.js`
  - now looks for `MONGODB_URI` in environmental variables
  - falls back to `mongodb://localhost/gittalk` if env var is not present
- [x] Adds `GITHUB_CALLBACK_URL` to passport config
  - required for GitHub social login
- [x] Adds `docker-compose.yml` to repo
  - run `docker-compose up` to start app with docker