### PR TITLE
(debug) cleanup chatroom defaults and fix a bunch of bugs

### DIFF
--- a/client/api/chatroom/chatroomRequest.js
+++ b/client/api/chatroom/chatroomRequest.js
@@ -19,11 +19,25 @@ function _post(url, data) {
 
 function init(repo) {
   return new Promise((resolve, reject) => {
-    _post('/api/chatroom/init', {repo: {id: repo}}).done(() => { 
+    _post('/api/chatroom/init', {repo: {
+        id: repo, 
+        messages: [{ 
+          type: 'message', 
+          chatroom: repo,
+          image: null, 
+          text: 'Welcome to GitTalk, chat away!', 
+          userAvatarUrl: '/assets/GitTalkLogo.png', 
+          user: 'GitTalk' 
+        }], 
+        apps: [{
+          read: { initPlaceholder: true },
+          write: { initPlaceholder: true }
+        }]
+      }}).done(() => { 
       resolve(); 
     }).fail((jqXHR, textStatus, err) => {
       reject(err);
-    })
+    });
   });
 }
 

--- a/client/api/chatroom/chatroomRequest.js
+++ b/client/api/chatroom/chatroomRequest.js
@@ -30,11 +30,22 @@ function init(repo) {
           user: 'GitTalk' 
         }], 
         apps: [{  // add placeholder app subscription for data field creation
-          read: { initPlaceholder: true },
+          read: { 'http://initPlaceholder': true },
           write: { initPlaceholder: true }
         }]
       }}).done(() => { 
       resolve(); 
+    }).fail((jqXHR, textStatus, err) => {
+      reject(err);
+    });
+  });
+}
+
+function getChatroom(repo) {
+  return new Promise((resolve, reject) => {
+    _get(`/api/chatroom/${repo}`)
+    .done((data) => { 
+      resolve(data); 
     }).fail((jqXHR, textStatus, err) => {
       reject(err);
     });
@@ -87,5 +98,6 @@ function sendInvite(chatroomLink, forkedRepoUrl) {
 
 module.exports = {
   init: init,
+  getChatroom: getChatroom,
   sendInvite: sendInvite
 }

--- a/client/api/chatroom/chatroomRequest.js
+++ b/client/api/chatroom/chatroomRequest.js
@@ -27,12 +27,13 @@ function init(repo) {
           image: null, 
           text: 'Welcome to GitTalk, chat away!', 
           userAvatarUrl: '/assets/GitTalkLogo.png', 
-          user: 'GitTalk' 
+          user: 'GitTalk'
         }], 
         apps: [{  // add placeholder app subscription for data field creation
           read: { 'http://initPlaceholder': true },
           write: { initPlaceholder: true }
-        }]
+        }],
+        members: ['placeholder'] // add member for data field creation
       }}).done(() => { 
       resolve(); 
     }).fail((jqXHR, textStatus, err) => {

--- a/client/api/chatroom/chatroomRequest.js
+++ b/client/api/chatroom/chatroomRequest.js
@@ -21,7 +21,7 @@ function init(repo) {
   return new Promise((resolve, reject) => {
     _post('/api/chatroom/init', {repo: {
         id: repo, 
-        messages: [{ 
+        messages: [{ // add placeholder message for user delight and data field creation
           type: 'message', 
           chatroom: repo,
           image: null, 
@@ -29,7 +29,7 @@ function init(repo) {
           userAvatarUrl: '/assets/GitTalkLogo.png', 
           user: 'GitTalk' 
         }], 
-        apps: [{
+        apps: [{  // add placeholder app subscription for data field creation
           read: { initPlaceholder: true },
           write: { initPlaceholder: true }
         }]

--- a/client/api/chatroom/messageRequest.js
+++ b/client/api/chatroom/messageRequest.js
@@ -15,7 +15,7 @@ function getMessages(chatroomid) {
       resolve(data);
     })
     .fail((jqXHR, textStatus, err) => {
-      console.log('error in getMessges', jqXHR, err);
+      console.log('error in getMessages', jqXHR, err);
       reject(err);
     });
   });

--- a/client/components/addApp.js
+++ b/client/components/addApp.js
@@ -12,6 +12,8 @@ import { githubGreen, githubBlue } from './../util/colorScheme.js';
 
 import { getAllApps, getSubscriptions } from './../api/app/appRequest.js';
 
+import { init, getChatroom } from './../api/chatroom/chatroomRequest.js';
+
 class AddApp extends React.Component {
   constructor(props) {
     super(props);
@@ -19,18 +21,6 @@ class AddApp extends React.Component {
     this.state = {
       open: false,
       apps: [ 
-        { name: 'Giffy', 
-          category: 'utility',
-          endpoint: 'giffy.herokuapp.com', 
-          owner: 'gifcat', 
-          apiKey: '345catcat9dd053f663b8ed496d2a'
-        },
-        { name: 'Weather', 
-          category: 'utility',
-          endpoint: 'weather.herokuapp.com', 
-          owner: 'weatherChannel', 
-          apiKey: '34567rainrain5c99dd053f663b8ed496d2a'
-        },
         { name: 'OlegBot', 
           category: 'chatbot',
           endpoint: 'olegbot.herokuapp.com', 
@@ -46,7 +36,15 @@ class AddApp extends React.Component {
   }
 
   updateSubscriptions() {
-    getAllApps()
+    getChatroom(this.props.reponame) // check if chatroom exists
+    .then(chatroom => {
+      if (chatroom === null) {
+        return init(this.props.reponame); // if not, initialize chatroom
+      } else {
+        return 'chatroom exists';
+      }
+    })
+    .then(() => getAllApps())
     .then(appdata => {
       getSubscriptions(this.props.reponame)
       .then(subsdata => {
@@ -81,7 +79,7 @@ class AddApp extends React.Component {
   }
 
   render() {
-    const style = { position: 'absolute', right: 0, top: 0, };
+    const style = { position: 'absolute', right: 0, top: 0, zIndex: 10 };
 
     const actions = <FlatButton
                       label='Done'
@@ -105,7 +103,7 @@ class AddApp extends React.Component {
                     </Dialog>;
 
     return (
-      <IconButton tooltip='SVG Icon' onClick={this.handleOpen} style={style}>
+      <IconButton tooltip='SVG Icon' onTouchTap={this.handleOpen} style={style}>
         <SettingsIcon />
         {dialog}
       </IconButton>

--- a/client/components/chatroom.js
+++ b/client/components/chatroom.js
@@ -83,10 +83,16 @@ class Chatroom extends React.Component {
     .catch(err => console.log('error in getMemberRepos', err));
   }
 
-  updateMessages() {
+  updateMessages(chatroomId) {
     // fetch all messages from DB
-    getMessages(this.state.chatroomId)
+    if (chatroomId === undefined) {
+      chatroomId = this.state.chatroomId;
+    } else {
+      this.setState({chatroomId: chatroomId});
+    }
+    getMessages(chatroomId)
     .then(messages => {
+      console.log('update messages to', chatroomId);
       this.setState({ messages: JSON.parse(messages) });
     })
     .catch(err => console.log(err));

--- a/client/components/createApp.js
+++ b/client/components/createApp.js
@@ -28,9 +28,8 @@ class CreateApp extends React.Component {
   };
 
   handleChange = (param, event) => {
-    console.log(this.state);
     this.setState({ [param]: event.target.value });
-  }
+  };
 
   saveApp = () => {
     createApp({

--- a/client/components/dashboard.js
+++ b/client/components/dashboard.js
@@ -3,7 +3,7 @@ import { Link, browserHistory } from 'react-router';
 import RepoList from './repoList.js';
 import Profile from './profile.js';
 import {getUser, getUserRepos } from './../api/user/userRequest.js';
-import { init } from '../api/chatroom/chatroomRequest.js';
+import { init, getChatroom } from '../api/chatroom/chatroomRequest.js';
 
 import Paper from 'material-ui/Paper';
 import { grey200 } from './../util/colorScheme';
@@ -23,7 +23,14 @@ class Dashboard extends React.Component {
 
   navToChatroom(name) {
     // Initiate chatroom
-    init(name).then(() => {
+    getChatroom(name) // check if chatroom exists
+    .then(chatroom => {
+      console.log('chatroom', chatroom);
+      if (chatroom === null) {
+        return init(name);
+      }
+    })
+    .then(() => {
       browserHistory.push(`/rooms/${name}`);
     }).catch(err => { 
       console.log(err); 

--- a/client/components/dashboard.js
+++ b/client/components/dashboard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, browserHistory } from 'react-router';
 import RepoList from './repoList.js';
 import Profile from './profile.js';
-import {getUser, getUserRepos } from './../api/user/userRequest.js';
+import { getUser, getUserRepos } from './../api/user/userRequest.js';
 import { init, getChatroom } from '../api/chatroom/chatroomRequest.js';
 
 import Paper from 'material-ui/Paper';
@@ -25,7 +25,6 @@ class Dashboard extends React.Component {
     // Initiate chatroom
     getChatroom(name) // check if chatroom exists
     .then(chatroom => {
-      console.log('chatroom', chatroom);
       if (chatroom === null) {
         return init(name);
       }

--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -55,7 +55,7 @@ class NavBar extends React.Component {
                             {channel}
                           </Link>}
                         innerDivStyle={listItemStyle}
-                        onClick={this.props.changeChannel}
+                        onClick={() => this.props.changeChannel(channel)}
                       />);
             })}
           </List>

--- a/client/components/repoListEntry.js
+++ b/client/components/repoListEntry.js
@@ -13,10 +13,10 @@ import AddApp from './addApp.js';
 const RepoListEntry = (props) => (
   <div>
     <ListItem
-      primaryText={ <span style={styles.primaryLink} onClick={props.navToChatroom.bind(this, props.repo.full_name)} >{props.repo.name}</span> }
+      primaryText={ <span style={styles.primaryLink} onTouchTap={props.navToChatroom.bind(this, props.repo.full_name)}>{props.repo.name}</span> }
       secondaryText={ props.repo.description }
       secondaryTextLines={ 1 }
-      leftIcon={<ChatIcon />}
+      leftIcon={<ChatIcon onTouchTap={props.navToChatroom.bind(this, props.repo.full_name)}/>}
       rightIcon={<AddApp reponame={props.repo.full_name} />}
     />
     <Divider />

--- a/server/db/controllers/chatroom.js
+++ b/server/db/controllers/chatroom.js
@@ -6,13 +6,14 @@ function findAll(member, callback) {
 }
 
 // findOne retrieves a chatroom with the associated id 
-function findOne(id, callback) {
+function findOneByIdJSON(id, callback) {
 	ChatroomModel.find({id: id}).lean().exec(callback);
-}
+} // lean().exec() returns data as JSON instead of mongoose document, needed for amending of existing fields
 
+// findOne retrieves a chatroom with the associated id 
 function findOneById(id, callback) {
-	ChatroomModel.find({id: id}, callback)
-}
+	ChatroomModel.find({id: id}, callback);
+} // returns mongoose document
 
 // updates current chatroom; creates one if it doesn't exist
 function update(chatroom, callback) {
@@ -43,7 +44,7 @@ function insertOne(chatroom, callback) {
 // }
 
 exports.findAll = findAll;
-exports.findOne = findOne;
+exports.findOneByIdJSON = findOneByIdJSON;
 exports.findOneById = findOneById;
 exports.insertOne = insertOne;
 exports.update = update;

--- a/server/handlers/apiHandler.js
+++ b/server/handlers/apiHandler.js
@@ -17,10 +17,9 @@ function getMessages (req, res) {
     } else {
       if (chatroom[0] === undefined) {
         throw 'error: chatroom does not exist';
-      } else if (chatroom[0].messages === undefined) {
-        chatroom[0].messages = [];
+      } else {
+    	  res.status(200).send(JSON.stringify(chatroom[0].messages));      
       }
-  	  res.status(200).send(JSON.stringify(chatroom[0].messages));
     } 
   });
 }

--- a/server/handlers/apiHandler.js
+++ b/server/handlers/apiHandler.js
@@ -9,9 +9,24 @@ function chatroomInit(req, res) {
   });
 }
 
+function getChatroom (req, res) {
+  const chatroomId = req.params.username + '/' + req.params.chatroom; 
+  chatroomCtrl.findOneById(chatroomId, (err, chatroom) => {
+    if (err) { 
+      throw err;
+    } else {
+      if (chatroom[0] === undefined) {
+        res.status(200).send(JSON.stringify(null));
+      } else {
+        res.status(200).send(JSON.stringify(chatroom[0]));      
+      }
+    } 
+  });
+}
+
 function getMessages (req, res) {
   const chatroomId = req.params.username + '/' + req.params.chatroom; 
-  chatroomCtrl.findOne(chatroomId, (err, chatroom) => {
+  chatroomCtrl.findOneById(chatroomId, (err, chatroom) => {
     if (err) { 
       throw err;
     } else {
@@ -75,6 +90,7 @@ function emailInvite (req, res) {
 module.exports = {
   chatroomInit: chatroomInit,
   emailInvite: emailInvite,
+  getChatroom: getChatroom,
   getMemberRepos: getMemberRepos,
   getMessages: getMessages
 }

--- a/server/handlers/appHandler.js
+++ b/server/handlers/appHandler.js
@@ -22,32 +22,23 @@ function createApp(req, res) {
 function subscribeApp(req, res) {
   const app = req.body.app;
   const chatroomId = req.body.reponame;
-  Chatroom.findOne(chatroomId, (err, chatroom) => {
+  Chatroom.findOneByIdJSON(chatroomId, (err, chatroom) => {
+    // method returns JSON instead of mongoose document
+    // so that existing fields can be edited
     if (err) { 
       throw err;
     } else {
       let room = chatroom[0];
       if (room === undefined) {
-        throw 'error: chatroom does not exist';
-      }
-      // let apps = room.apps;
-      if (room.apps === undefined) {
-        room.apps = [{
-          read: {},
-          write: {}
-        }];
-      }else if (room.apps[0] === undefined) {
-        room.apps.push({
-          read: {},
-          write: {}
-        });
-      }
-      room.apps[0].read[app.endpoint.split('.').join('%dot%')] = true;
-      room.apps[0].write[app.apiKey] = true;
+        res.status(400).end();
+      } else {
+        room.apps[0].read[app.endpoint.split('.').join('%dot%')] = true;
+        room.apps[0].write[app.apiKey] = true;
 
-      Chatroom.update(room, () => {
-        res.status(201).end();        
-      });
+        Chatroom.update(room, () => {
+          res.status(201).end();        
+        });        
+      }
     } 
   });
 }
@@ -55,27 +46,23 @@ function subscribeApp(req, res) {
 function unsubscribeApp(req, res) {
   const app = req.body.app;
   const chatroomId = req.body.reponame;
-  Chatroom.findOne(chatroomId, (err, chatroom) => {
+  Chatroom.findOneByIdJSON(chatroomId, (err, chatroom) => {
+    // method returns JSON instead of mongoose document
+    // so that existing fields can be edited
     if (err) { 
       throw err;
     } else {
       let room = chatroom[0];
       if (room === undefined) {
-        throw 'error: chatroom does not exist';
-      }
-      let apps = room.apps;
-      if (apps[0] === undefined) {
-        apps.push({
-          read: {},
-          write: {}
-        });
-      }
-      delete apps[0].read[app.endpoint.split('.').join('%dot%')];
-      delete apps[0].write[app.apiKey];
+        res.status(400).end();
+      } else {
+        delete room.apps[0].read[app.endpoint.split('.').join('%dot%')];
+        delete room.apps[0].write[app.apiKey];
 
-      Chatroom.update(room, () => {
-        res.status(201).end();        
-      });
+        Chatroom.update(room, () => {
+          res.status(201).end();        
+        });        
+      }
     } 
   });
 }
@@ -98,22 +85,9 @@ function getSubscriptions(req, res) {
     } else {
       let room = chatroom[0];
       if (room === undefined) {
-        // refactor: attempt again to store apps in object? create chatrooms ahead of time?
-        res.status(200).send(JSON.stringify({ read: {}, write: {} }));
-        // throw 'error: chatroom does not exist';
+        res.status(400).end();
       } else {
-        let apps = room.apps;
-        if (apps === undefined) {
-          res.status(200).send(JSON.stringify({ read: {}, write: {} }));
-        } else if (apps[0] === undefined) {
-          apps.push({
-            read: {},
-            write: {}
-          });
-          res.status(200).send(JSON.stringify(apps[0]));        
-        } else {
-          res.status(200).send(JSON.stringify(apps[0])); 
-        }
+        res.status(200).send(JSON.stringify(room.apps[0])); 
       }
     } 
   });

--- a/server/handlers/appHandler.js
+++ b/server/handlers/appHandler.js
@@ -79,7 +79,7 @@ function getAllApps(req, res) {
 
 function getSubscriptions(req, res) {
   const chatroomId = req.params.username + '/' + req.params.chatroom;
-  Chatroom.findOne(chatroomId, (err, chatroom) => {
+  Chatroom.findOneById(chatroomId, (err, chatroom) => {
     if (err) { 
       throw err;
     } else {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -4,6 +4,8 @@ const apiHandler = require('../handlers/apiHandler.js');
 
 router.post('/chatroom/init', apiHandler.chatroomInit);
 
+router.get('/chatroom/:username/:chatroom', apiHandler.getChatroom);
+
 router.post('/email/invite', apiHandler.emailInvite); 
 
 router.get('/messages/:username/:chatroom', apiHandler.getMessages);

--- a/server/socket/socket.js
+++ b/server/socket/socket.js
@@ -16,21 +16,14 @@ function listen(server) {
         if (err) {throw err;}
         const room = chatroom[0];
         if (room === undefined) { throw 'error: chatroom does not exist'; }
-        if (room.members === undefined) {
-          room.members = [];
-        }
         if (room.members.indexOf(msg.user) === -1) {
           room.members.push(msg.user);
         }
-        if (room.messages === undefined) {
-          room.messages = [];
-        }
         room.messages.push(msg);
-
         room.save();
-        // chatroomCtrl.update(room, () => {
+
         if (room.apps[0].read) outbound.send(room, msg);
-        // });
+
       });
     });
   });

--- a/test/db/index.spec.js
+++ b/test/db/index.spec.js
@@ -75,7 +75,7 @@ describe('Chatroom Model', () => {
 
   it('should find a chatroom by id', done => {
     ChatroomController.insertOne(chat1, () => {
-      ChatroomController.findOne('DYWXaStMxp/GypORHVxal', (err, res) => {
+      ChatroomController.findOneById('DYWXaStMxp/GypORHVxal', (err, res) => {
         expect(err).to.not.exist;
         expect(res[0].id).to.equal('DYWXaStMxp/GypORHVxal');
         done();


### PR DESCRIPTION
- chatroom init now sets defaults for messages, apps, and members to absolve other handlers from injecting defaults.
- chatrooms are now created for all repos upon login for app subscriptions to work properly on the dashboard.
- fixed changeChannels as it was acting weird during user testing.
- enable moving to chatroom when click on repoListEntry's chat icon. still disabled clicking the entire listItem, otherwise addApp (cog icon on the right) will not open when clicked on.